### PR TITLE
Fix Ruby output capture for multi-arg puts

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,8 +142,10 @@
                 var buffer = [];
 
                 // Override puts method to capture output
-                Opal.top.$puts = function(str) {
-                    buffer.push(str);
+                Opal.top.$puts = function() {
+                    for (var i = 0; i < arguments.length; i++) {
+                        buffer.push(arguments[i]);
+                    }
                 };
 
                 // Compile and execute the Ruby code


### PR DESCRIPTION
## Summary
- handle multiple arguments in `puts` when capturing output

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f517973288321bb4a1812a6745c54