### PR TITLE
Add puppeteer test and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "rubycompiler",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "puppeteer": "^21.3.8"
+  }
+}

--- a/tests/rubyCompiler.test.js
+++ b/tests/rubyCompiler.test.js
@@ -1,0 +1,29 @@
+const puppeteer = require('puppeteer');
+const path = require('path');
+
+describe('Ruby Compiler page', () => {
+  let browser;
+  let page;
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({args:['--no-sandbox']});
+    page = await browser.newPage();
+    const filePath = 'file://' + path.resolve(__dirname, '../index.html');
+    await page.goto(filePath);
+  });
+
+  afterAll(async () => {
+    if (browser) await browser.close();
+  });
+
+  test('executes simple ruby snippet', async () => {
+    await page.waitForSelector('#editor');
+    await page.evaluate(() => {
+      ace.edit('editor').setValue('puts 1+1');
+    });
+    await page.click('#run-code');
+    await page.waitForFunction(() => document.querySelector('#output').textContent.trim() !== '');
+    const output = await page.$eval('#output', el => el.textContent.trim());
+    expect(output).toBe('2');
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- add Jest + Puppeteer test to check that the Ruby snippet `puts 1+1` prints `2`
- add basic `package.json` with test dependencies
- run tests in a new GitHub Actions workflow

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842f886d0fc8321a86fb219b49b595f